### PR TITLE
メモ投稿機能のサーバーサイド実装

### DIFF
--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -7,8 +7,8 @@ class PostsController < ApplicationController
   # end
 
   def create
-    Post.create(content: params[:content])
-    redirect_to action: :index
+    post = Post.create(content: params[:content], checked: false)
+    render json: { post: post }
   end
 
   def checked

--- a/app/javascript/memo.js
+++ b/app/javascript/memo.js
@@ -1,0 +1,32 @@
+function memo() {
+    const submit = document.getElementById("submit");
+    submit.addEventListener("click", (e) => {
+        const formData = new FormData(document.getElementById("form"));
+        const XHR = new XMLHttpRequest();
+        XHR.open("POST", "/posts", true);
+        XHR.responseType = "json";
+        XHR.send(formData);
+        XHR.onload = () => {
+            if (XHR.status != 200) {
+                alert(`Error ${XHR.status}: ${XHR.statusText}`);
+                return null;
+            }
+            const item = XHR.response.post;
+            const list = document.getElementById("list");
+            const formText = document.getElementById("content");
+            const HTML = `
+              <div class="post" data-id=${item.id}>
+                <div class="post-date">
+                投稿日時：${item.created_at}
+                </div>
+                <div class="post-content">
+                ${item.content}
+                </div>
+              </div>`;
+            list.insertAdjacentHTML("afterend", HTML);
+            formText.value = "";
+        };
+        e.preventDefault();
+    });
+}
+window.addEventListener("load", memo);

--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -1,8 +1,11 @@
 <h1>AjaxApp</h1>
 <%= form_with url: "/posts", method: :post,id: "form" do |form| %>
-  <%= form.text_field :content %>
+  <%= form.text_field :content , id: "content" %>
   <%= form.submit '投稿する' , id: "submit" %>
 <% end %>
+
+<div id="list">
+</div>
 
 <% @posts.each do |post| %>
   <div class="post" data-id=<%= post.id%> data-check=<%= post.checked %>>


### PR DESCRIPTION
# what
１メモ投稿機能のサーバーサイドで、post/controller.rbのcreateアクション変更。
２メモ投稿機能のフロンサイドで、DOMの取得、ブラウザ上のメモ投稿を可能にするJavaScriptを記述。
# why
１非同期でメモ作成時に未読の情報を保存するため。
非同期でレスポンスをJSONに変更するため。

２非同期で、メモ投稿をするため。